### PR TITLE
Fix nomodel identity perf regression

### DIFF
--- a/src/identity.cc
+++ b/src/identity.cc
@@ -27,7 +27,6 @@
 #include <map>
 #include <memory>
 #include <thread>
-
 #include "triton/backend/backend_common.h"
 #include "triton/backend/backend_model.h"
 #include "triton/backend/backend_model_instance.h"


### PR DESCRIPTION
The legacy custom identity backend did not need to do these comparisons. Hence the drop in performance we noticed
Set string find is much slower than for integers.