### PR TITLE
Resolve Warmup Error

### DIFF
--- a/src/identity.cc
+++ b/src/identity.cc
@@ -627,13 +627,7 @@ TRITONBACKEND_ModelInstanceExecute(
   uint64_t exec_start_ns = 0;
   SET_TIMESTAMP(exec_start_ns);
 
-  bool supports_batching = false;
-  // SupportsFirstDimBatching returns "Server not ready" when called
-  // during warmup, which can be ignored as warmup does not batch.
-  auto err = model_state->SupportsFirstDimBatching(&supports_batching);
-  if (err != nullptr && TRITONSERVER_ErrorCode(err) != TRITONSERVER_ERROR_UNAVAILABLE){
-    return err;
-  }
+  bool supports_batching = model_state->SupportsFirstDimBatching();
 
   // 'responses' is initialized with the response objects below and
   // if/when an error response is sent the corresponding entry in


### PR DESCRIPTION
This PR resolves the "Server not ready" error received when a model with warmup enabled in the config is loaded. This backend relies on a shared function, SupportFirstDimBatching, to get whether the first dimension can be batched. However, that function is intended to only be used when the server is ready. So it does not work for the warmup function, since the models are still being loaded.

Since the issue is isolated to this backend, this PR aims to fix the issue while keeping the scope within this backend. I modified the identity backend to handle the expected exception. In the case of warmup, batching does not matter, so the code will run the warmup requests and load the model. If the model or server is unavailable for a regular request, it will return an error during the run phase (SupportFirstDimBatching was never meant to be used as a test for model availability).

PRs in this change (merge together):
https://github.com/triton-inference-server/backend/pull/47
https://github.com/triton-inference-server/identity_backend/pull/15
https://github.com/triton-inference-server/server/pull/3692