### PR TITLE
Custom metric API example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION. All rights reserved.
+# Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,13 @@ target_compile_options(
   $<$<CXX_COMPILER_ID:MSVC>:/Wall /D_WIN32_WINNT=0x0A00 /EHsc>
 )
 
+if(${TRITON_ENABLE_METRICS})
+  target_compile_definitions(
+    triton-identity-backend
+    PRIVATE TRITON_ENABLE_METRICS=1
+  )
+endif() # TRITON_ENABLE_METRICS
+
 target_link_libraries(
   triton-identity-backend
   PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ project(tritonidentitybackend LANGUAGES C CXX)
 #
 option(TRITON_ENABLE_GPU "Enable GPU support in backend" OFF)
 option(TRITON_ENABLE_STATS "Include statistics collections in backend" ON)
+option(TRITON_ENABLE_METRICS "Include metrics API in backend" ON)
 
 set(TRITON_COMMON_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/common repo")
 set(TRITON_CORE_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/core repo")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,8 +38,8 @@ project(tritonidentitybackend LANGUAGES C CXX)
 # support GPUs.
 #
 option(TRITON_ENABLE_GPU "Enable GPU support in backend" OFF)
-option(TRITON_ENABLE_STATS "Include statistics collection in backend" ON)
-option(TRITON_ENABLE_METRICS "Include metrics collection in backend" ON)
+option(TRITON_ENABLE_STATS "Include statistics collections in backend" ON)
+option(TRITON_ENABLE_METRICS "Include metrics support in backend" ON)
 
 set(TRITON_COMMON_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/common repo")
 set(TRITON_CORE_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/core repo")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,8 +38,8 @@ project(tritonidentitybackend LANGUAGES C CXX)
 # support GPUs.
 #
 option(TRITON_ENABLE_GPU "Enable GPU support in backend" OFF)
-option(TRITON_ENABLE_STATS "Include statistics collections in backend" ON)
-option(TRITON_ENABLE_METRICS "Include metrics API in backend" ON)
+option(TRITON_ENABLE_STATS "Include statistics collection in backend" ON)
+option(TRITON_ENABLE_METRICS "Include metrics collection in backend" ON)
 
 set(TRITON_COMMON_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/common repo")
 set(TRITON_CORE_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/core repo")

--- a/README.md
+++ b/README.md
@@ -70,3 +70,22 @@ the following additional cmake flags:
 -DTRITON_CORE_REPO_TAG=r21.10
 -DTRITON_COMMON_REPO_TAG=r21.10
 ```
+
+## Custom Metric Example
+
+When `TRITON_ENABLE_METRICS` is enabled, this backend implements an example
+of registering a custom metric to Triton's existing metrics endpoint via the
+[Metrics API](https://github.com/triton-inference-server/server/blob/main/docs/metrics.md#custom-metrics).
+
+This metric will track the cumulative `input_byte_size` of all requests
+to this backend per-model. Here's an example output of the custom metric
+from Triton's metrics endpoint after a few requests to each model: 
+
+```
+# HELP input_byte_size_counter Cumulative input byte size of all requests received by the model
+# TYPE input_byte_size_counter counter
+input_byte_size_counter{model="identity_uint32",version="1"} 64.000000
+input_byte_size_counter{model="identity_fp32",version="1"} 32.000000
+```
+
+This example can be referenced to implement custom metrics for various use cases.

--- a/src/identity.cc
+++ b/src/identity.cc
@@ -206,6 +206,10 @@ ModelState::ValidateModelConfig()
     RETURN_IF_ERROR(input.MemberAsString("data_type", &input_dtype));
     RETURN_IF_ERROR(output.MemberAsString("data_type", &output_dtype));
 
+    // TODO: Track counts of each input type to backend / model
+    // MetricFamily -> TypeCount
+    // Metrics -> Labels for each type name
+
     // Input and output must have same shape or reshaped shape
     std::vector<int64_t> input_shape, output_shape;
     triton::common::TritonJson::Value reshape;

--- a/src/identity.cc
+++ b/src/identity.cc
@@ -489,7 +489,8 @@ TRITONBACKEND_Initialize(TRITONBACKEND_Backend* backend)
 #ifdef TRITON_ENABLE_METRICS
   // Create metric family
   const char* family_name = "input_byte_size_counter";
-  const char* desc = "Sum total input_byte_size across all identity models";
+  const char* desc =
+      "Cumulative input_byte_size across all identity model requests";
   TRITONSERVER_MetricKind kind = TRITONSERVER_METRIC_KIND_COUNTER;
   RETURN_IF_ERROR(TRITONSERVER_MetricFamilyNew(
       &state->metric_family_, kind, family_name, desc));

--- a/src/identity.cc
+++ b/src/identity.cc
@@ -592,10 +592,6 @@ TRITONBACKEND_ModelInitialize(TRITONBACKEND_Model* model)
   // across backend
   RETURN_IF_ERROR(
       model_state->InitMetrics(backend_state->metric_family_, name, version));
-#else
-  // TODO: Remove
-  LOG_MESSAGE(
-      TRITONSERVER_LOG_ERROR, "TRITON_ENABLE_METRICS not defined, but it should be.");
 #endif  // TRITON_ENABLE_METRICS
 
   return nullptr;  // success

--- a/src/identity.cc
+++ b/src/identity.cc
@@ -87,7 +87,7 @@ struct IdentityBackendState {
   {
 #ifdef TRITON_ENABLE_METRICS
     if (metric_family_ != nullptr) {
-        TRITONSERVER_MetricFamilyDelete(metric_family_);
+      TRITONSERVER_MetricFamilyDelete(metric_family_);
     }
 #endif  // TRITON_ENABLE_METRICS
   }
@@ -180,7 +180,9 @@ ModelState::ModelState(TRITONBACKEND_Model* triton_model)
 ModelState::~ModelState()
 {
 #ifdef TRITON_ENABLE_METRICS
-  TRITONSERVER_MetricDelete(input_byte_size_counter_);
+  if (input_byte_size_counter_ != nullptr) {
+    TRITONSERVER_MetricDelete(input_byte_size_counter_);
+  }
 #endif  // TRITON_ENABLE_METRICS
 }
 

--- a/src/identity.cc
+++ b/src/identity.cc
@@ -592,6 +592,10 @@ TRITONBACKEND_ModelInitialize(TRITONBACKEND_Model* model)
   // across backend
   RETURN_IF_ERROR(
       model_state->InitMetrics(backend_state->metric_family_, name, version));
+#else
+  // TODO: Remove
+  LOG_MESSAGE(
+      TRITONSERVER_LOG_ERROR, "TRITON_ENABLE_METRICS not defined, but it should be.");
 #endif  // TRITON_ENABLE_METRICS
 
   return nullptr;  // success

--- a/src/identity.cc
+++ b/src/identity.cc
@@ -37,9 +37,6 @@
 #include <cuda_runtime_api.h>
 #endif  // TRITON_ENABLE_GPU
 
-// TODO
-#define TRITON_ENABLE_METRICS 1
-
 namespace triton { namespace backend { namespace identity {
 
 //


### PR DESCRIPTION
Adds an example of adding a custom metric family global to the backend with BackendState, and per-model metrics added to the global metric family by each ModelState via `labels`:
```
root@RMCCORMICK:/mnt/jira/3557-metrics-example/server/qa/L0_backend_identity# grep byte_size client.log
# HELP input_byte_size_counter Cumulative input_byte_size across all identity model requests
# TYPE input_byte_size_counter counter
input_byte_size_counter{model="identity_bytes",version="1"} 0.000000
input_byte_size_counter{model="identity_fp32",version="1"} 0.000000
input_byte_size_counter{model="identity_nobatch_int8",version="1"} 0.000000
input_byte_size_counter{model="identity_uint32",version="1"} 64.000000
```

Updated unit test and documentation here: https://github.com/triton-inference-server/server/pull/4211