### PR TITLE
Support parallel instance loading

### DIFF
--- a/src/identity.cc
+++ b/src/identity.cc
@@ -1249,6 +1249,22 @@ TRITONBACKEND_ModelInstanceExecute(
   return nullptr;  // success
 }
 
+TRITONSERVER_Error*
+TRITONBACKEND_GetBackendAttribute(
+    TRITONBACKEND_Backend* backend,
+    TRITONBACKEND_BackendAttribute* backend_attributes)
+{
+  LOG_MESSAGE(
+      TRITONSERVER_LOG_VERBOSE,
+      "TRITONBACKEND_GetBackendAttribute: setting attributes");
+  // This backend can safely handle parallel calls to
+  // TRITONBACKEND_ModelInstanceInitialize (thread-safe).
+  RETURN_IF_ERROR(TRITONBACKEND_BackendAttributeSetParallelInstanceLoading(
+      backend_attributes, true));
+
+  return nullptr;
+}
+
 }  // extern "C"
 
 }}}  // namespace triton::backend::identity

--- a/src/identity.cc
+++ b/src/identity.cc
@@ -25,6 +25,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <algorithm>
+#include <atomic>
 #include <map>
 #include <memory>
 #include <thread>
@@ -116,8 +117,8 @@ class ModelState : public BackendModel {
     return optional_inputs_;
   }
 
-  // Stores the instance count
-  size_t instance_count_;
+  // Stores the instance count. Atomic to protect reads/writes by all instances.
+  std::atomic<size_t> instance_count_;
 
   // Validate that model configuration is supported by this backend.
   TRITONSERVER_Error* ValidateModelConfig();

--- a/src/identity.cc
+++ b/src/identity.cc
@@ -1261,14 +1261,8 @@ TRITONBACKEND_GetBackendAttribute(
       "TRITONBACKEND_GetBackendAttribute: setting attributes");
   // This backend can safely handle parallel calls to
   // TRITONBACKEND_ModelInstanceInitialize (thread-safe).
-  // TODO: Return to hard-coded. Using env var for testing.
-  bool supported = true;
-  const char* env = getenv("IDENTITY_PARALLEL");
-  if (env != nullptr) {
-    supported = (std::string(env) == "1");
-  }
   RETURN_IF_ERROR(TRITONBACKEND_BackendAttributeSetParallelInstanceLoading(
-      backend_attributes, supported));
+      backend_attributes, true));
 
   return nullptr;
 }

--- a/src/identity.cc
+++ b/src/identity.cc
@@ -1260,7 +1260,7 @@ TRITONBACKEND_GetBackendAttribute(
   // This backend can safely handle parallel calls to
   // TRITONBACKEND_ModelInstanceInitialize (thread-safe).
   // TODO: Return to hard-coded. Using env var for testing.
-  bool supported = false;
+  bool supported = true;
   const char* env = getenv("IDENTITY_PARALLEL");
   if (env != nullptr) {
     supported = (std::string(env) == "1");

--- a/src/identity.cc
+++ b/src/identity.cc
@@ -1259,8 +1259,14 @@ TRITONBACKEND_GetBackendAttribute(
       "TRITONBACKEND_GetBackendAttribute: setting attributes");
   // This backend can safely handle parallel calls to
   // TRITONBACKEND_ModelInstanceInitialize (thread-safe).
+  // TODO: Return to hard-coded. Using env var for testing.
+  bool supported = false;
+  const char* env = getenv("IDENTITY_PARALLEL");
+  if (env != nullptr) {
+    supported = (std::string(env) == "1");
+  }
   RETURN_IF_ERROR(TRITONBACKEND_BackendAttributeSetParallelInstanceLoading(
-      backend_attributes, true));
+      backend_attributes, supported));
 
   return nullptr;
 }

--- a/src/identity.cc
+++ b/src/identity.cc
@@ -1261,7 +1261,7 @@ TRITONBACKEND_GetBackendAttribute(
       "TRITONBACKEND_GetBackendAttribute: setting attributes");
   // This backend can safely handle parallel calls to
   // TRITONBACKEND_ModelInstanceInitialize (thread-safe).
-  RETURN_IF_ERROR(TRITONBACKEND_BackendAttributeSetParallelInstanceLoading(
+  RETURN_IF_ERROR(TRITONBACKEND_BackendAttributeSetParallelModelInstanceLoading(
       backend_attributes, true));
 
   return nullptr;


### PR DESCRIPTION
Example backend to sanity test core PR for loading model instances in parallel: https://github.com/triton-inference-server/core/pull/235

L0_batcher failures appeared due to instance_id getting set to zero or incorrect values for multiple instances, causing the [delay values](https://github.com/triton-inference-server/identity_backend/blob/17037b40a2637a8e9ea13c46535c9b672a8b0de7/src/identity.cc#L820-L824) to be wrong.

This PR fixes L0_batcher tests when identity backend has parallel instance loading enabled.
