### PR TITLE
Bumping min required cxx standard to 17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,9 @@ cmake_minimum_required(VERSION 3.17)
 
 project(tritonidentitybackend LANGUAGES C CXX)
 
+# Use C++17 standard as Triton's minimum required.
+set(TRITON_MIN_CXX_STANDARD 17 CACHE STRING "The minimum C++ standard which features are requested to build this target.")
+
 #
 # Options
 #
@@ -97,7 +100,7 @@ target_include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
-target_compile_features(triton-identity-backend PRIVATE cxx_std_11)
+target_compile_features(triton-identity-backend PRIVATE cxx_std_${TRITON_MIN_CXX_STANDARD})
 target_compile_options(
   triton-identity-backend PRIVATE
   $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:


### PR DESCRIPTION
This PR is one of the series PRs to update Triton to C++17 standard.

Introduced logic: either set `TRITON_MIN_CXX_STANDARD` to 17 or use cached value. Later,`TRITON_MIN_CXX_STANDARD`  is used to set min required standard through `target_compile_features`.